### PR TITLE
Add support for Nexus 3.40.1-01.  Nexus 3.40.1-01 is now using ElasticSearch.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=com.vestmark.nexus.plugins
-version=1.4.0.0
+version=1.5.0.0
 
-nexusVersion=3.28.0-01
+nexusVersion=3.40.1-01

--- a/src/main/java/com/vestmark/nexus/plugin/maven/BaseMavenResource.java
+++ b/src/main/java/com/vestmark/nexus/plugin/maven/BaseMavenResource.java
@@ -30,7 +30,7 @@ import org.sonatype.goodies.common.ComponentSupport;
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.group.GroupFacet;
 import org.sonatype.nexus.repository.manager.RepositoryManager;
-import org.sonatype.nexus.repository.search.SearchService;
+import org.sonatype.nexus.repository.search.ElasticSearchService;
 import org.sonatype.nexus.rest.Resource;
 
 @SuppressWarnings("unchecked")
@@ -46,10 +46,10 @@ public abstract class BaseMavenResource
   protected static final String CONTENT = "content";
   protected static final String LAST_MODIFIED = "last_modified";
 
-  protected final SearchService searchService;
+  protected final ElasticSearchService searchService;
   protected final RepositoryManager repositoryManager;
 
-  protected BaseMavenResource(SearchService searchService, RepositoryManager repositoryManager)
+  protected BaseMavenResource(ElasticSearchService searchService, RepositoryManager repositoryManager)
   {
     this.searchService = searchService;
     this.repositoryManager = repositoryManager;

--- a/src/main/java/com/vestmark/nexus/plugin/maven/MavenResource.java
+++ b/src/main/java/com/vestmark/nexus/plugin/maven/MavenResource.java
@@ -37,7 +37,7 @@ import org.sonatype.nexus.blobstore.api.Blob;
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.group.GroupFacet;
 import org.sonatype.nexus.repository.manager.RepositoryManager;
-import org.sonatype.nexus.repository.search.SearchService;
+import org.sonatype.nexus.repository.search.ElasticSearchService;
 import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.storage.Query;
 import org.sonatype.nexus.repository.storage.StorageFacet;
@@ -62,7 +62,7 @@ public class MavenResource
   private static final String BLOBSTORE_CONTENT_TYPE = "BlobStore.content-type";
 
   @Inject
-  public MavenResource(SearchService searchService, RepositoryManager repositoryManager)
+  public MavenResource(ElasticSearchService searchService, RepositoryManager repositoryManager)
   {
     super(searchService, repositoryManager);
   }

--- a/src/main/java/com/vestmark/nexus/plugin/maven/rundeck/RundeckMavenResource.java
+++ b/src/main/java/com/vestmark/nexus/plugin/maven/rundeck/RundeckMavenResource.java
@@ -26,7 +26,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import org.sonatype.nexus.repository.manager.RepositoryManager;
-import org.sonatype.nexus.repository.search.SearchService;
+import org.sonatype.nexus.repository.search.ElasticSearchService;
 
 import com.vestmark.nexus.plugin.maven.BaseMavenResource;
 
@@ -38,7 +38,7 @@ public class RundeckMavenResource
 {
 
   @Inject
-  public RundeckMavenResource(SearchService searchService, RepositoryManager repositoryManager)
+  public RundeckMavenResource(ElasticSearchService searchService, RepositoryManager repositoryManager)
   {
     super(searchService, repositoryManager);
   }


### PR DESCRIPTION
Add support for Nexus 3.40.1-01.  Nexus 3.40.1-01 is now using ElasticSearch.

Please note the differences between versions in Nexus open source.
-https://github.com/sonatype/nexus-public/blob/release-3.30.1-01/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/search/SearchService.java
-https://github.com/sonatype/nexus-public/blob/release-3.40.1-01/components/nexus-repository/src/main/java/org/sonatype/nexus/repository/search/ElasticSearchService.java

Fortunately, the searchUnrestricted java method being called by us has not undergone a name or interface change.  So only the references to SearchService need to change to ElasticSearchService.

Stacktrace excerpt before changes:
_2022-07-22 12:55:12,037-0400 WARN  [qtp54703337-2762]  admin org.sonatype.nexus.siesta.internal.UnexpectedExceptionMapper - (ID e12e2cb4-3da9-476a-97b6-04a5ed6ea4a6) Unexpected exception: java.lang.NoSuchMethodError: org.sonatype.nexus.repository.search.SearchService.searchUnrestricted(Lorg/elasticsearch/index/query/QueryBuilder;Ljava/util/List;II)Lorg/elasticsearch/action/search/SearchResponse;
java.lang.NoSuchMethodError: org.sonatype.nexus.repository.search.SearchService.searchUnrestricted(Lorg/elasticsearch/index/query/QueryBuilder;Ljava/util/List;II)Lorg/elasticsearch/action/search/SearchResponse;
        at com.vestmark.nexus.plugin.maven.BaseMavenResource.searchMavenArtifacts(BaseMavenResource.java:121)
        at com.vestmark.nexus.plugin.maven.BaseMavenResource.listVersions(BaseMavenResource.java:146)
        at com.vestmark.nexus.plugin.maven.rundeck.RundeckMavenResource.versions(RundeckMavenResource.java:57)_

After changes, no stacktrace and successful execution.
